### PR TITLE
[ci skip] adding user @AidanWiederhold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @chrisburr
+* @AidanWiederhold

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,4 +56,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - AidanWiederhold
     - chrisburr


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @AidanWiederhold as instructed in #19.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #19